### PR TITLE
Inputs, Forms, and Validation

### DIFF
--- a/examples/all.ts
+++ b/examples/all.ts
@@ -1,4 +1,4 @@
-// TODO(jdd): auto generate import/exports for examples during the grunt site-meta task.
+// TODO(jd): auto generate import/exports for examples during the grunt site-meta task.
 
 
 import {CONST_EXPR, Type} from 'angular2/src/facade/lang';

--- a/examples/all.ts
+++ b/examples/all.ts
@@ -19,15 +19,17 @@ import TabsDynamicTabs from './components/tabs/dynamic_tabs';
 import CheckboxBasicUsage from "./components/checkbox/basic_usage";
 import CheckboxSyncing from "./components/checkbox/syncing";
 import ListBasicUsage from "./components/list/basic_usage";
+import InputBasicUsage from "./components/input/basic_usage";
 
 /**
- * Collection of Material Design component directives.
+ * Collection of Material Design component example directives.
  */
 export const DEMO_DIRECTIVES: Type[] = CONST_EXPR([
   CardBasicUsage, CardInlineActions, CardActionButtons,
   ButtonBasicUsage,
   CheckboxBasicUsage, CheckboxSyncing,
   DialogBasicUsage,
+  InputBasicUsage,
   ListBasicUsage,
   RadioBasicUsage,
   SwitchBasicUsage,

--- a/examples/all.ts
+++ b/examples/all.ts
@@ -20,6 +20,7 @@ import CheckboxBasicUsage from "./components/checkbox/basic_usage";
 import CheckboxSyncing from "./components/checkbox/syncing";
 import ListBasicUsage from "./components/list/basic_usage";
 import InputBasicUsage from "./components/input/basic_usage";
+import {InputFormBuilder} from "./components/input/form_builder";
 
 /**
  * Collection of Material Design component example directives.
@@ -30,6 +31,7 @@ export const DEMO_DIRECTIVES: Type[] = CONST_EXPR([
   CheckboxBasicUsage, CheckboxSyncing,
   DialogBasicUsage,
   InputBasicUsage,
+  InputFormBuilder,
   ListBasicUsage,
   RadioBasicUsage,
   SwitchBasicUsage,

--- a/examples/components/input/basic_usage.html
+++ b/examples/components/input/basic_usage.html
@@ -61,16 +61,13 @@
 
           <md-input-container class="md-block" flex-gt-sm>
             <label>Postal Code</label>
-            <!--<br>TODO: remove this: {{postalCode.errors | json}}-->
             <input md-input ngControl="postalCode" [(value)]="user.postalCode" placeholder="12345"
               required mdPattern="^[0-9]{5}$" #postalCode="ngForm" mdMaxLength="5">
 
-            <div md-messages role="alert" multiple [hidden]="postalCode.valid || postalCode.pristine">
-              <div [hidden]="!postalCode.errors?.required" md-message>You must supply a postal code.</div>
-              <div [hidden]="!postalCode.errors?.mdPattern" md-message>That doesn't look like a valid postal code.</div>
-              <div [hidden]="!postalCode.errors?.mdMaxLength" md-message>
-                Don't use the long version silly...we don't need to be that specific...
-              </div>
+            <div [md-messages]="postalCode" role="alert">
+              <div md-message="required">You must supply a postal code.</div>
+              <div md-message="mdPattern">That doesn't look like a valid postal code.</div>
+              <div md-message="mdMaxLength">Don't use the long version silly...we don't need to be that specific...</div>
             </div>
           </md-input-container>
         </div>

--- a/examples/components/input/basic_usage.html
+++ b/examples/components/input/basic_usage.html
@@ -1,0 +1,90 @@
+<div layout="column" class="md-inline-form">
+
+  <md-content md-theme="docs-dark" layout-gt-sm="row" layout-padding>
+    <div>
+      <md-input-container>
+        <label>Title</label>
+        <input md-input [(value)]="user.title">
+      </md-input-container>
+
+      <md-input-container>
+        <label>Email</label>
+        <input md-input [(value)]="user.email" type="email">
+      </md-input-container>
+    </div>
+  </md-content>
+
+  <md-content layout-padding>
+    <div>
+      <form name="userForm">
+
+        <div layout-gt-xs="row">
+          <md-input-container class="md-block" flex-gt-xs>
+            <label>Company (Disabled)</label>
+            <input md-input [(value)]="user.company" disabled>
+          </md-input-container>
+        </div>
+
+        <div layout-gt-sm="row">
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>First name</label>
+            <input md-input [(value)]="user.firstName">
+          </md-input-container>
+
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Last Name</label>
+            <input md-input [(value)]="user.lastName">
+          </md-input-container>
+        </div>
+
+        <md-input-container class="md-block">
+          <label>Address</label>
+          <input md-input [(value)]="user.address">
+        </md-input-container>
+
+        <md-input-container md-no-float class="md-block">
+          <input md-input [(value)]="user.address2" placeholder="Address 2">
+        </md-input-container>
+
+        <div layout-gt-sm="row">
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>City</label>
+            <input md-input [(value)]="user.city">
+          </md-input-container>
+
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>State</label>
+            <select [(value)]="user.state">
+              <option *ngFor="#state of states" [value]="state.abbrev">
+                {{state.abbrev}}
+              </option>
+            </select>
+          </md-input-container>
+
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Postal Code</label>
+            <!--<br>TODO: remove this: {{postalCode.errors | json}}-->
+            <input md-input ngControl="postalCode" [(value)]="user.postalCode" placeholder="12345"
+              required mdPattern="^[0-9]{5}$" #postalCode="ngForm" mdMaxLength="5">
+
+            <div md-messages role="alert" multiple [hidden]="postalCode.valid || postalCode.pristine">
+              <div [hidden]="!postalCode.errors?.required" md-message>You must supply a postal code.</div>
+              <div [hidden]="!postalCode.errors?.mdPattern" md-message>That doesn't look like a valid postal code.</div>
+              <div [hidden]="!postalCode.errors?.mdMaxLength" md-message>
+                Don't use the long version silly...we don't need to be that specific...
+              </div>
+            </div>
+          </md-input-container>
+        </div>
+
+        <md-input-container class="md-block">
+          <label>Biography</label>
+          <textarea md-input [(value)]="user.biography" columns="1" md-maxlength="150" rows="5"></textarea>
+        </md-input-container>
+
+
+      </form>
+    </div>
+  </md-content>
+
+</div>

--- a/examples/components/input/basic_usage.html
+++ b/examples/components/input/basic_usage.html
@@ -1,22 +1,20 @@
 <div layout="column" class="md-inline-form">
 
-  <md-content md-theme="docs-dark" layout-gt-sm="row" layout-padding>
-    <div>
-      <md-input-container>
-        <label>Title</label>
-        <input md-input [(value)]="user.title">
-      </md-input-container>
-
-      <md-input-container>
-        <label>Email</label>
-        <input md-input [(value)]="user.email" type="email">
-      </md-input-container>
-    </div>
-  </md-content>
-
   <md-content layout-padding>
     <div>
       <form name="userForm">
+
+        <div layout-gt-sm="row">
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Title</label>
+            <input md-input [(value)]="user.title">
+          </md-input-container>
+
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Email</label>
+            <input md-input [(value)]="user.email" type="email">
+          </md-input-container>
+        </div>
 
         <div layout-gt-xs="row">
           <md-input-container class="md-block" flex-gt-xs>

--- a/examples/components/input/basic_usage.html
+++ b/examples/components/input/basic_usage.html
@@ -1,5 +1,9 @@
 <div layout="column" class="md-inline-form">
 
+  <md-toolbar md-hero layout="row" layout-align="center center" layout-align-gt-md="end end">
+    <i class="secret-project" md-icon>person</i>
+  </md-toolbar>
+
   <md-content layout-padding>
     <div>
       <form name="userForm">
@@ -62,12 +66,13 @@
           <md-input-container class="md-block" flex-gt-sm>
             <label>Postal Code</label>
             <input md-input ngControl="postalCode" [(value)]="user.postalCode" placeholder="12345"
-              required mdPattern="^[0-9]{5}$" #postalCode="ngForm" mdMaxLength="5">
+                   required mdPattern="^[0-9]{5}$" #postalCode="ngForm" mdMaxLength="5">
 
             <div [md-messages]="postalCode" role="alert">
               <div md-message="required">You must supply a postal code.</div>
               <div md-message="mdPattern">That doesn't look like a valid postal code.</div>
-              <div md-message="mdMaxLength">Don't use the long version silly...we don't need to be that specific...</div>
+              <div md-message="mdMaxLength">Don't use the long version silly...we don't need to be that specific...
+              </div>
             </div>
           </md-input-container>
         </div>

--- a/examples/components/input/basic_usage.scss
+++ b/examples/components/input/basic_usage.scss
@@ -1,0 +1,5 @@
+md-input-container > select {
+  margin: 0;
+  order: 2;
+  display: flex;
+}

--- a/examples/components/input/basic_usage.ts
+++ b/examples/components/input/basic_usage.ts
@@ -1,0 +1,33 @@
+import {View, Component} from 'angular2/core';
+import {MATERIAL_DIRECTIVES} from 'ng2-material/all';
+import {FORM_DIRECTIVES, Validators} from 'angular2/common';
+
+@Component({selector: 'input-basic-usage'})
+@View({
+  templateUrl: 'examples/components/input/basic_usage.html',
+  styleUrls: ['examples/components/input/basic_usage.css'],
+  directives: [MATERIAL_DIRECTIVES, FORM_DIRECTIVES]
+})
+export default class InputBasicUsage {
+  user = {
+    title: 'Developer',
+    email: 'ipsum@lorem.com',
+    firstName: '',
+    lastName: '',
+    company: 'Google',
+    address: '1600 Amphitheatre Pkwy',
+    address2: '',
+    city: 'Mountain View',
+    state: 'CA',
+    biography: 'Loves kittens, snowboarding, and can type at 130 WPM.\n\nAnd rumor has it she bouldered up Castle Craig!',
+    postalCode: '94043'
+  };
+
+  states = [
+    'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME',
+    'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA',
+    'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'
+  ].map(function (state) {
+    return {abbrev: state};
+  })
+}

--- a/examples/components/input/form_builder.html
+++ b/examples/components/input/form_builder.html
@@ -1,0 +1,54 @@
+<div layout="column">
+
+  <md-content layout-padding>
+    <form [ngFormModel]="projectForm">
+
+      <md-input-container class="md-block">
+        <label for="description">Description</label>
+        <input md-input ngControl="description" id="description" [(value)]="description">
+        <div md-messages="description">
+          <div md-message="required">This is required.</div>
+          <div md-message="maxlength">The name has to be less than 30 characters long.</div>
+        </div>
+      </md-input-container>
+
+      <md-input-container class="md-block">
+        <label for="clientName">Client Name</label>
+        <input md-input ngControl="clientName" id="clientName" [(value)]="clientName">
+        <div md-messages="clientName" role="alert">
+          <div md-message="required">This is required.</div>
+        </div>
+      </md-input-container>
+
+      <md-input-container class="md-block">
+        <label for="clientEmail">Client Email</label>
+        <input md-input type="email" ngControl="clientEmail" id="clientEmail" [(value)]="clientEmail"/>
+        <div md-messages="clientEmail" role="alert">
+          <div md-message>Your email must be between 10 and 100 characters long and look like an e-mail address.</div>
+        </div>
+      </md-input-container>
+
+      <md-input-container class="md-block">
+        <label for="rate">Hourly Rate (USD)</label>
+        <input md-input type="number" step="any" ngControl="rate" id="rate" [(value)]="rate" #rateInput/>
+        <div md-messages="rate" role="alert">
+          <div md-message="mdNumberRequired">
+            You've got to charge something! You can't just <b>give away</b> a Missile Defense
+            System.
+          </div>
+          <div md-message="mdMin">
+            You should charge at least $800 an hour. This job is a big deal... if you mess up,
+            everyone dies!
+          </div>
+          <div md-message="mdPattern">
+            You should charge exactly $1,234.
+          </div>
+          <div md-message="mdMax">
+            ${{rateInput.value}} an hour? That's a little ridiculous. I doubt event Bill Clinton could afford that.
+          </div>
+        </div>
+      </md-input-container>
+    </form>
+  </md-content>
+
+</div>

--- a/examples/components/input/form_builder.html
+++ b/examples/components/input/form_builder.html
@@ -1,11 +1,22 @@
 <div layout="column">
 
+  <md-toolbar md-hero layout="row" layout-align="center center" layout-align-gt-md="end end">
+    <h1>{{description}}</h1>
+    <a class="secret-project" href="https://materialdesignicons.com/icon/rocket" target="_blank">
+      <svg viewBox="0 0 24 24">
+        <path
+          d="M2.81,14.12L5.64,11.29L8.17,10.79C11.39,6.41 17.55,4.22 19.78,4.22C19.78,6.45 17.59,12.61 13.21,15.83L12.71,18.36L9.88,21.19L9.17,17.66C7.76,17.66 7.76,17.66 7.05,16.95C6.34,16.24 6.34,16.24 6.34,14.83L2.81,14.12M5.64,16.95L7.05,18.36L4.39,21.03H2.97V19.61L5.64,16.95M4.22,15.54L5.46,15.71L3,18.16V16.74L4.22,15.54M8.29,18.54L8.46,19.78L7.26,21H5.84L8.29,18.54M13,9.5A1.5,1.5 0 0,0 11.5,11A1.5,1.5 0 0,0 13,12.5A1.5,1.5 0 0,0 14.5,11A1.5,1.5 0 0,0 13,9.5Z"/>
+      </svg>
+    </a>
+  </md-toolbar>
+
   <md-content layout-padding>
+
     <form [ngFormModel]="projectForm">
 
       <md-input-container class="md-block">
         <label for="description">Description</label>
-        <input md-input ngControl="description" id="description" [(value)]="description">
+        <input md-input ngControl="description" id="description" [(value)]="model.description">
         <div md-messages="description">
           <div md-message="required">This is required.</div>
           <div md-message="maxlength">The name has to be less than 30 characters long.</div>
@@ -14,7 +25,7 @@
 
       <md-input-container class="md-block">
         <label for="clientName">Client Name</label>
-        <input md-input ngControl="clientName" id="clientName" [(value)]="clientName">
+        <input md-input ngControl="clientName" id="clientName" [(value)]="model.clientName">
         <div md-messages="clientName" role="alert">
           <div md-message="required">This is required.</div>
         </div>
@@ -22,7 +33,7 @@
 
       <md-input-container class="md-block">
         <label for="clientEmail">Client Email</label>
-        <input md-input type="email" ngControl="clientEmail" id="clientEmail" [(value)]="clientEmail"/>
+        <input md-input type="email" ngControl="clientEmail" id="clientEmail" [(value)]="model.clientEmail"/>
         <div md-messages="clientEmail" role="alert">
           <div md-message>Your email must be between 10 and 100 characters long and look like an e-mail address.</div>
         </div>
@@ -30,7 +41,7 @@
 
       <md-input-container class="md-block">
         <label for="rate">Hourly Rate (USD)</label>
-        <input md-input type="number" step="any" ngControl="rate" id="rate" [(value)]="rate" #rateInput/>
+        <input md-input type="number" step="any" ngControl="rate" id="rate" [(value)]="model.rate" #rateInput/>
         <div md-messages="rate" role="alert">
           <div md-message="mdNumberRequired">
             You've got to charge something! You can't just <b>give away</b> a Missile Defense

--- a/examples/components/input/form_builder.scss
+++ b/examples/components/input/form_builder.scss
@@ -2,19 +2,12 @@
 @import '../../../ng2-material/core/style/mixins';
 @import '../../../ng2-material/core/style/default-theme';
 
-.secret-project {
-  width: 256px;
-  height: 256px;
-  font-size: 256px;
-  color: md-color($md-primary,900,0.6);
-}
-
 md-toolbar[md-hero] {
   margin-bottom: 40px;
 }
 
-md-input-container > select {
-  margin: 0;
-  order: 2;
-  display: flex;
+.secret-project {
+  width: 256px;
+  height: 256px;
+  fill: white;
 }

--- a/examples/components/input/form_builder.ts
+++ b/examples/components/input/form_builder.ts
@@ -1,0 +1,38 @@
+import {View, Component} from 'angular2/core';
+import {MdPatternValidator, MdMinValueValidator, MdNumberRequiredValidator, MdMaxValueValidator, MATERIAL_DIRECTIVES} from 'ng2-material/all';
+import {FORM_DIRECTIVES, Validators, FormBuilder, ControlGroup} from 'angular2/common';
+
+@Component({selector: 'input-form-builder'})
+@View({
+  templateUrl: 'examples/components/input/form_builder.html',
+  directives: [MATERIAL_DIRECTIVES, FORM_DIRECTIVES]
+})
+export class InputFormBuilder {
+  projectForm: ControlGroup;
+  clientName: string = '';
+  clientEmail: string = '';
+  description: string = 'Nuclear Missile Defense System';
+  rate: number = 500;
+
+  constructor(fb: FormBuilder) {
+    this.projectForm = fb.group({
+      'clientName': ['', Validators.required],
+      'description': ['', Validators.compose([
+        Validators.required,
+        Validators.maxLength(30)
+      ])],
+      'clientEmail': ['', Validators.compose([
+        MdPatternValidator.inline('^.+@.+\..+$'),
+        Validators.required,
+        Validators.minLength(10),
+        Validators.maxLength(100)
+      ])],
+      'rate': ['', Validators.compose([
+        MdNumberRequiredValidator.inline(),
+        MdPatternValidator.inline('^1234$'),
+        MdMinValueValidator.inline(800),
+        MdMaxValueValidator.inline(4999)
+      ])]
+    });
+  }
+}

--- a/examples/components/input/form_builder.ts
+++ b/examples/components/input/form_builder.ts
@@ -5,15 +5,17 @@ import {FORM_DIRECTIVES, Validators, FormBuilder, ControlGroup} from 'angular2/c
 @Component({selector: 'input-form-builder'})
 @View({
   templateUrl: 'examples/components/input/form_builder.html',
+  styleUrls: ['examples/components/input/form_builder.css'],
   directives: [MATERIAL_DIRECTIVES, FORM_DIRECTIVES]
 })
 export class InputFormBuilder {
   projectForm: ControlGroup;
-  clientName: string = '';
-  clientEmail: string = '';
-  description: string = 'Nuclear Missile Defense System';
-  rate: number = 500;
-
+  model = {
+    clientName: '',
+    clientEmail: '',
+    description: 'Nuclear Missile Defense System',
+    rate: 500
+  };
   constructor(fb: FormBuilder) {
     this.projectForm = fb.group({
       'clientName': ['', Validators.required],

--- a/ng2-material/all.scss
+++ b/ng2-material/all.scss
@@ -17,6 +17,7 @@
 @import "components/icon/icon";
 @import "components/input/input";
 @import "components/list/list";
+@import "components/form/messages";
 @import "components/peekaboo/peekaboo";
 @import "components/progress_circular/progress_circular";
 @import "components/progress_linear/progress_linear";

--- a/ng2-material/all.ts
+++ b/ng2-material/all.ts
@@ -21,11 +21,12 @@ export * from './components/grid_list/grid_list';
 import {MdIcon} from './components/icon/icon';
 export * from './components/icon/icon';
 
-import {
-  MdInput, MdInputContainer,
-  MdPatternValidator, MdMaxLengthValidator,
-  INPUT_VALIDATORS
-} from './components/input/input';
+import {MdPatternValidator, MdMaxLengthValidator,INPUT_VALIDATORS} from './components/form/validators';
+export * from './components/form/validators';
+import {MdMessage, MdMessages} from './components/form/messages';
+export * from './components/form/messages';
+
+import {MdInput, MdInputContainer} from './components/input/input';
 export * from './components/input/input';
 
 import {MdList, MdListItem} from './components/list/list';
@@ -70,6 +71,7 @@ export const MATERIAL_DIRECTIVES: Type[] = CONST_EXPR([
   MdGridList, MdGridTile,
   MdIcon,
   MdInput, MdInputContainer, MdPatternValidator, MdMaxLengthValidator,
+  MdMessage, MdMessages,
   MdList, MdListItem,
   MdPeekaboo,
   MdProgressLinear,

--- a/ng2-material/all.ts
+++ b/ng2-material/all.ts
@@ -21,7 +21,12 @@ export * from './components/grid_list/grid_list';
 import {MdIcon} from './components/icon/icon';
 export * from './components/icon/icon';
 
-import {MdPatternValidator, MdMaxLengthValidator,INPUT_VALIDATORS} from './components/form/validators';
+import {
+  MdPatternValidator, MdMaxLengthValidator,
+  MdMinValueValidator, MdMaxValueValidator,
+  MdNumberRequiredValidator,
+  INPUT_VALIDATORS
+} from './components/form/validators';
 export * from './components/form/validators';
 import {MdMessage, MdMessages} from './components/form/messages';
 export * from './components/form/messages';
@@ -70,7 +75,10 @@ export const MATERIAL_DIRECTIVES: Type[] = CONST_EXPR([
   MdDivider,
   MdGridList, MdGridTile,
   MdIcon,
-  MdInput, MdInputContainer, MdPatternValidator, MdMaxLengthValidator,
+  MdInput, MdInputContainer,
+  MdPatternValidator, MdMaxLengthValidator,
+  MdMinValueValidator, MdMaxValueValidator,
+  MdNumberRequiredValidator,
   MdMessage, MdMessages,
   MdList, MdListItem,
   MdPeekaboo,

--- a/ng2-material/all.ts
+++ b/ng2-material/all.ts
@@ -21,7 +21,11 @@ export * from './components/grid_list/grid_list';
 import {MdIcon} from './components/icon/icon';
 export * from './components/icon/icon';
 
-import {MdInput, MdInputContainer} from './components/input/input';
+import {
+  MdInput, MdInputContainer,
+  MdPatternValidator, MdMaxLengthValidator,
+  INPUT_VALIDATORS
+} from './components/input/input';
 export * from './components/input/input';
 
 import {MdList, MdListItem} from './components/list/list';
@@ -65,7 +69,7 @@ export const MATERIAL_DIRECTIVES: Type[] = CONST_EXPR([
   MdDivider,
   MdGridList, MdGridTile,
   MdIcon,
-  MdInput, MdInputContainer,
+  MdInput, MdInputContainer, MdPatternValidator, MdMaxLengthValidator,
   MdList, MdListItem,
   MdPeekaboo,
   MdProgressLinear,
@@ -83,5 +87,6 @@ export const MATERIAL_DIRECTIVES: Type[] = CONST_EXPR([
 export const MATERIAL_PROVIDERS: any[] = [
   MdDialog,
   Media,
-  MdRadioDispatcher
+  MdRadioDispatcher,
+  INPUT_VALIDATORS
 ];

--- a/ng2-material/components/form/messages.scss
+++ b/ng2-material/components/form/messages.scss
@@ -30,10 +30,6 @@ form {
     // Default state for messages is to be visible
     opacity: 1;
     margin-top: 0;
-
-    // Add some top padding which is equal to half the difference between the expected height
-    // and the actual height
-    padding-top: $error-padding-top;
   }
 
   .md-input-message-animation {

--- a/ng2-material/components/form/messages.scss
+++ b/ng2-material/components/form/messages.scss
@@ -11,32 +11,10 @@ form {
     order: 4;
     overflow: hidden;
     @include rtl(clear, left, right);
-
-    &[hidden] {
-      // Upon entering the DOM, messages should be hidden
-      md-message,
-      [md-message] {
-        opacity: 0;
-        margin-top: -100px;
-      }
-    }
   }
 
   md-message, [md-message] {
     overflow: hidden;
-
-    transition: $swift-ease-in;
-
-    // Default state for messages is to be visible
-    opacity: 1;
-    margin-top: 0;
-  }
-
-  .md-input-message-animation {
-    &.ng-enter {
-      opacity: 0;
-      margin-top: -100px;
-    }
   }
 
 }

--- a/ng2-material/components/form/messages.scss
+++ b/ng2-material/components/form/messages.scss
@@ -1,0 +1,46 @@
+@import "../../core/style/variables";
+@import "../../core/style/default-theme";
+@import "../../core/style/mixins";
+
+form {
+  //
+  // ngMessage base styles - animations moved to input.js
+  //
+  md-messages, [md-messages] {
+    position: relative;
+    order: 4;
+    overflow: hidden;
+    @include rtl(clear, left, right);
+
+    &[hidden] {
+      // Upon entering the DOM, messages should be hidden
+      md-message,
+      [md-message] {
+        opacity: 0;
+        margin-top: -100px;
+      }
+    }
+  }
+
+  md-message, [md-message] {
+    overflow: hidden;
+
+    transition: $swift-ease-in;
+
+    // Default state for messages is to be visible
+    opacity: 1;
+    margin-top: 0;
+
+    // Add some top padding which is equal to half the difference between the expected height
+    // and the actual height
+    padding-top: $error-padding-top;
+  }
+
+  .md-input-message-animation {
+    &.ng-enter {
+      opacity: 0;
+      margin-top: -100px;
+    }
+  }
+
+}

--- a/ng2-material/components/form/messages.ts
+++ b/ng2-material/components/form/messages.ts
@@ -1,0 +1,83 @@
+import {CONST_EXPR} from "angular2/src/facade/lang";
+import {NG_VALIDATORS} from "angular2/common";
+import {
+  Attribute, Input, Provider, Directive, Optional, SkipSelf, Host, OnDestroy, OnInit,
+  ContentChildren, QueryList, Query, AfterContentInit
+} from "angular2/core";
+import {Validator, NgFormModel, NgControlName} from "angular2/common";
+import {Control} from "angular2/common";
+import {isPresent} from "angular2/src/facade/lang";
+
+
+@Directive({
+  selector: '[md-message]',
+  host: {
+    '[hidden]': 'okay'
+  }
+})
+export class MdMessage {
+  @Input('md-message') errorKey: string;
+
+  okay: boolean = true;
+
+  constructor(@Attribute('md-message') pattern: any) {
+    if (isPresent(pattern)) {
+      this.errorKey = pattern;
+    }
+  }
+}
+
+
+@Directive({
+  selector: '[md-messages]',
+  host: {
+    'md-messages': '',
+    '[hidden]': 'valid || !property?.touched',
+    '[class.md-valid]': 'valid && property?.touched',
+    '[class.md-invalid]': '!valid && property?.touched'
+  }
+})
+export class MdMessages implements OnInit, OnDestroy {
+
+  @Input('md-messages') property: string|NgControlName;
+
+  valid: boolean;
+
+  constructor(@Query(MdMessage) public messages: QueryList<MdMessage>,
+              @Optional() @SkipSelf() @Host() public form: NgFormModel,
+              @Attribute('md-messages') pattern: any) {
+    if (isPresent(pattern)) {
+      this.property = pattern;
+    }
+  }
+
+  private _unsubscribe: any = null;
+
+  ngOnInit() {
+    if (this.property instanceof NgControlName) {
+      let ctrl: NgControlName = <NgControlName>this.property;
+      this.form = ctrl.formDirective;
+      this._unsubscribe = (<any>ctrl).update.subscribe(this._valueChanged.bind(this));
+    }
+    else {
+      if (!this.form) {
+        throw new Error('md-messages cannot bind to text property without a parent NgFormModel');
+      }
+      console.log('init formbuilder property: ' + this.property);
+    }
+  }
+
+  ngOnDestroy(): any {
+    this._unsubscribe();
+  }
+
+  private _valueChanged(newValue: string) {
+    let ctrl: NgControlName = <NgControlName>this.property;
+    this.valid = !ctrl.errors;
+    if (ctrl.errors) {
+      this.messages.toArray().forEach((m: MdMessage) => {
+        m.okay = !isPresent(ctrl.errors[m.errorKey]);
+      });
+    }
+  }
+}

--- a/ng2-material/components/form/messages.ts
+++ b/ng2-material/components/form/messages.ts
@@ -19,7 +19,7 @@ import {isPresent} from 'angular2/src/facade/lang';
 @Directive({
   selector: '[md-message]',
   host: {
-    '[hidden]': 'okay'
+    '[style.display]': 'okay ? "none" : "inherit"'
   }
 })
 export class MdMessage {
@@ -39,7 +39,7 @@ export class MdMessage {
   selector: '[md-messages]',
   host: {
     'md-messages': '',
-    '[hidden]': 'valid || !isTouched',
+    '[style.display]': '(valid || !isTouched) ? "none" : "inherit"',
     '[class.md-valid]': 'valid && isTouched',
     '[class.md-invalid]': '!valid && isTouched'
   }

--- a/ng2-material/components/form/messages.ts
+++ b/ng2-material/components/form/messages.ts
@@ -48,7 +48,7 @@ export class MdMessages implements OnInit, OnDestroy {
 
   @Input('md-messages') property: string|NgControlName;
 
-  valid: boolean;
+  valid: boolean = true;
 
   get isTouched(): boolean {
     if (this.property instanceof NgControlName) {

--- a/ng2-material/components/form/validators.ts
+++ b/ng2-material/components/form/validators.ts
@@ -3,6 +3,7 @@ import {NG_VALIDATORS} from "angular2/common";
 import {Attribute, Input, Provider, Directive,forwardRef} from "angular2/core";
 import {Validator} from "angular2/common";
 import {Control} from "angular2/common";
+import {isNumber} from '../../core/util/util';
 import {isPresent, NumberWrapper} from 'angular2/src/facade/lang';
 
 const PATTERN_VALIDATOR = CONST_EXPR(new Provider(NG_VALIDATORS, {
@@ -152,7 +153,8 @@ export class MdNumberRequiredValidator implements Validator {
    */
   static inline(): Function {
     return function validate(control: Control): {[key: string]: any} {
-      return !NumberWrapper.isNaN(control.value) ? null : {mdRequired: true};
+      let isNum = !NumberWrapper.isNaN(control.value) && isNumber(control.value);
+      return isNum ? null : {mdNumberRequired: true};
     }
   }
 

--- a/ng2-material/components/form/validators.ts
+++ b/ng2-material/components/form/validators.ts
@@ -16,6 +16,16 @@ const PATTERN_VALIDATOR = CONST_EXPR(new Provider(NG_VALIDATORS, {
 })
 export class MdPatternValidator implements Validator {
 
+  /**
+   * Static method that returns a validator function for use
+   * with {@see FormBuilder}.
+   * @param pattern The regular expression to match.
+   * @returns A Validator function that may be used with
+   */
+  static match(pattern:string):Function {
+    return new MdPatternValidator(pattern).validate;
+  }
+
   @Input('mdPattern') mdPattern: string;
 
   constructor(@Attribute('mdPattern') pattern: any) {

--- a/ng2-material/components/input/input.scss
+++ b/ng2-material/components/input/input.scss
@@ -1,7 +1,6 @@
 @import "../../core/style/variables";
-
-// TODO(jelbourn): This goes away.
 @import "../../core/style/default-theme";
+@import "../../core/style/mixins";
 
 @mixin input-placeholder-color($color) {
   &::-webkit-input-placeholder,
@@ -16,7 +15,7 @@ $input-container-padding: 2px !default;
 
 $input-label-default-offset: 24px !default;
 $input-label-default-scale: 1.0 !default;
-$input-label-float-offset: 4px !default;
+$input-label-float-offset: 6px !default;
 $input-label-float-scale: 0.75 !default;
 
 $input-placeholder-offset: $input-label-default-offset !default;
@@ -31,24 +30,40 @@ $input-full-width-padding-top: 16px !default;
 
 $input-error-font-size: 12px !default;
 $input-error-height: 24px !default;
+$input-error-line-height: $input-error-font-size + 2px;
+$error-padding-top: ($input-error-height - $input-error-line-height) / 2;
+
+$icon-offset: 36px !default;
+
+$icon-float-focused-top: -8px !default;
 
 md-input-container {
-  box-sizing: border-box;
-  display: flex;
+  @include pie-clearfix();
+  display: inline-block;
   position: relative;
-  flex-direction: column;
-
-  overflow-x: hidden;
   padding: $input-container-padding;
-  padding-bottom: $input-container-padding + $input-error-height;
+  margin: 18px 0;
+  vertical-align: middle;
+
+  &.md-block {
+    display: block;
+  }
+
+  // Setup a spacer that is always there as a placeholder for any messages so we don't change
+  // height with only 1 message
+  .md-errors-spacer {
+    @include rtl(float, right, left);
+    min-height: $input-error-height;
+
+    // Ensure the element always takes up space, even if empty
+    min-width: 1px;
+  }
 
   > md-icon {
     position: absolute;
     top: 5px;
-    left: 2px;
-    + input {
-      margin-left: 28px * 2;
-    }
+    @include rtl(left, 2px, auto);
+    @include rtl(right, auto, 2px);
   }
 
   textarea,
@@ -66,34 +81,43 @@ md-input-container {
   input[type="search"],
   input[type="tel"],
   input[type="color"] {
-    // Remove default appearance from all input / textarea.
-    // `appearance` is not supported in IE, but does IE apply any txt input styling?
+    /* remove default appearance from all input/textarea */
     -moz-appearance: none;
     -webkit-appearance: none;
-    appearance: none;
   }
-
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="month"],
+  input[type="time"],
+  input[type="week"] {
+    min-height: $input-line-height;
+  }
   textarea {
     resize: none;
     overflow: hidden;
   }
 
   textarea.md-input {
-    min-height: 2 * $input-line-height + $input-border-width-focused + $input-padding-top;
-    -ms-flex-preferred-size: auto; // IE10
+    min-height: $input-line-height;
+    -ms-flex-preferred-size: auto; //IE fix
   }
 
-  label:not(.md-no-float) {
-    order: 1;
-    pointer-events: none;
-    -webkit-font-smoothing: antialiased;
-    padding-left: $input-container-padding;
-    z-index: 1;
-    transform: translate3d(0, $input-label-default-offset, 0) scale($input-label-default-scale);
-    transform-origin: left top;
-    transition: transform $swift-ease-out-timing-function 0.25s;
+  label:not(.md-container-ignore) {
+    position: absolute;
+    bottom: 100%;
+    @include rtl(left, 0, auto);
+    @include rtl(right, auto, 0);
   }
 
+  // icon offset should have higher priority as normal label
+  &.md-has-icon {
+    @include rtl(padding-left, $icon-offset, 0);
+    @include rtl(padding-right, 0, $icon-offset);
+    > label {
+      @include rtl(left, $icon-offset, auto);
+      @include rtl(right, auto, $icon-offset);
+    }
+  }
   .md-placeholder {
     position: absolute;
     top: 0;
@@ -101,8 +125,19 @@ md-input-container {
     transition-property: opacity, transform;
     transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
   }
-  &.md-full-width {
-    padding-bottom: 0;
+
+  label:not(.md-no-float):not(.md-container-ignore),
+  .md-placeholder {
+    order: 1;
+    pointer-events: none;
+    -webkit-font-smoothing: antialiased;
+    @include rtl(padding-left, $input-container-padding + 1px, 0);
+    @include rtl(padding-right, 0, $input-container-padding + 1px);
+    z-index: 1;
+    transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
+    transition: transform $swift-ease-out-timing-function 0.25s;
+
+    @include rtl(transform-origin, left top, right top);
   }
   &.md-input-focused .md-placeholder {
     opacity: 1;
@@ -114,25 +149,48 @@ md-input-container {
     opacity: 0;
   }
 
-  &:not( .md-input-has-value ) input:not( :focus ) {
+  &:not( .md-input-has-value ) input:not( :focus ),
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-ampm-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-day-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-hour-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-millisecond-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-minute-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-month-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-second-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-week-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-year-field,
+  &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-text {
     color: transparent;
   }
-
 
   /*
    * The .md-input class is added to the input/textarea
    */
   .md-input {
-    flex: 1 1 auto;
     order: 2;
     display: block;
+    margin-top: 0;
 
     background: none;
-    padding: $input-padding-top 2px $input-border-width-focused - $input-border-width-default;
+    padding-top: $input-padding-top;
+    padding-bottom: $input-border-width-focused - $input-border-width-default;
+    padding-left: 2px;
+    padding-right: 2px;
     border-width: 0 0 $input-border-width-default 0;
     line-height: $input-line-height;
-    -ms-flex-preferred-size: $input-line-height; // IE10
+    height: $input-line-height + ($input-padding-top * 2);
+    -ms-flex-preferred-size: $input-line-height; //IE fix
     border-radius: 0;
+    border-style: solid; // Firefox fix
+
+    // Fix number inputs in Firefox to be full-width
+    width: 100%;
+    box-sizing: border-box;
+
+    // Hacky fix to force vertical alignment between `input` and `textarea`
+    // Input and textarea do not align by default:
+    // http://jsbin.com/buqomevage/1/edit?html,css,js,output
+    @include rtl(float, left, right);
 
     &:focus {
       outline: none;
@@ -141,35 +199,105 @@ md-input-container {
       outline: none;
       box-shadow: none;
     }
-  }
-  &.md-full-width {
-    .md-input {
-      padding: $input-full-width-padding-top 2px;
-      line-height: $input-full-width-line-height;
-      -ms-flex-preferred-size: $input-full-width-line-height; // IE10
+
+    &.md-no-flex {
+      flex: none !important;
     }
   }
 
   .md-char-counter {
-    -webkit-font-smoothing: antialiased;
-    position: absolute;
-    font-size: $input-error-font-size;
-    line-height: $input-error-height;
-    bottom: $input-container-padding;
-    right: $input-container-padding;
+    @include rtl(text-align, right, left);
+    @include rtl(padding-right, $input-container-padding, 0);
+    @include rtl(padding-left, 0, $input-container-padding);
+  }
 
-    // TODO(jelbourn): animations here.
+  //
+  // ngMessage base styles - animations moved to input.js
+  //
+  md-messages, [md-messages] {
+    position: relative;
+    order: 4;
+    overflow: hidden;
+    @include rtl(clear, left, right);
+
+    &[hidden] {
+      // Upon entering the DOM, messages should be hidden
+      md-message,
+      [md-message] {
+        opacity: 0;
+        margin-top: -100px;
+      }
+    }
+  }
+
+  md-message, [md-message],
+  .md-char-counter {
+    font-size: $input-error-font-size;
+    line-height: $input-error-line-height;
+    overflow: hidden;
+
+    transition: $swift-ease-in;
+
+    // Default state for messages is to be visible
+    opacity: 1;
+    margin-top: 0;
+
+    // Add some top padding which is equal to half the difference between the expected height
+    // and the actual height
+    padding-top: $error-padding-top;
+
+    &:not(.md-char-counter) {
+      // Add some padding so that the messages don't touch the character counter
+      @include rtl(padding-right, rem(0.5), 0);
+      @include rtl(padding-left, 0, rem(0.5));
+    }
+  }
+
+  &:not(.md-input-invalid) {
+    .md-auto-hide {
+      .md-input-message-animation {
+        opacity: 0;
+        margin-top: -100px;
+      }
+    }
+  }
+
+  // Note: This is a workaround to fix an ng-enter flicker bug
+  .md-auto-hide {
+    .md-input-message-animation {
+      &:not(.ng-animate) {
+        opacity: 0;
+        margin-top: -100px;
+      }
+    }
+  }
+
+  .md-input-message-animation {
+    &.ng-enter {
+      opacity: 0;
+      margin-top: -100px;
+    }
   }
 
   &.md-input-focused,
+  &.md-input-has-placeholder,
   &.md-input-has-value {
     label:not(.md-no-float) {
-      transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
+      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
+    }
+  }
+
+  // If we have an existing value; don't animate the transform as it happens on page load and
+  // causes erratic/unnecessary animation
+  &.md-input-has-value {
+    label {
+      transition: none;
     }
   }
 
   // Use wide border in error state or in focused state
-  &.md-input-focused .md-input &:not(.md-full-width) {
+  &.md-input-focused .md-input,
+  .md-input.ng-invalid.ng-dirty {
     padding-bottom: 0; // Increase border width by 1px, decrease padding by 1
     border-width: 0 0 $input-border-width-focused 0;
   }
@@ -180,12 +308,58 @@ md-input-container {
       background-position: 0 bottom;
       // This background-size is coordinated with a linear-gradient set in input-theme.scss
       // to create a dotted line under the input.
-      background-size: 3px 1px;
+      background-size: 4px 1px;
       background-repeat: repeat-x;
+      margin-bottom: -1px; // Shift downward so dotted line is positioned the same as other bottom borders
     }
   }
 }
 
+md-input-container.md-icon-float {
+
+  transition: margin-top 0.5s $swift-ease-out-timing-function;
+
+  > label {
+    pointer-events: none;
+    position: absolute;
+  }
+
+  > md-icon {
+    top: 2px;
+    @include rtl(left, 2px, auto);
+    @include rtl(right, auto, 2px);
+  }
+
+  &.md-input-focused,
+  &.md-input-has-value {
+
+    label {
+      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
+      transition: transform $swift-ease-out-timing-function 0.5s;
+    }
+  }
+
+}
+
+md-input-container.md-icon-right {
+  @include rtl(padding-right, $icon-offset, $icon-offset);
+  @include rtl(padding-left, $icon-offset, $icon-offset);
+
+  .md-errors-spacer {
+    + md-icon {
+      margin: 0;
+
+      @include rtl(right, 2px, auto);
+      @include rtl(left, auto, 2px);
+    }
+  }
+}
+
+@media screen and (-ms-high-contrast: active) {
+  md-input-container.md-default-theme > md-icon {
+    fill: #fff;
+  }
+}
 
 // THEME
 
@@ -207,7 +381,7 @@ md-input-container {
     color: md-color($md-foreground, hint-text);
   }
 
-  div[ng-messages] {
+  div[md-messages] {
     color: md-color($md-warn, 500)
   }
 

--- a/ng2-material/components/input/input.scss
+++ b/ng2-material/components/input/input.scss
@@ -211,41 +211,10 @@ md-input-container {
     @include rtl(padding-left, 0, $input-container-padding);
   }
 
-  //
-  // ngMessage base styles - animations moved to input.js
-  //
-  md-messages, [md-messages] {
-    position: relative;
-    order: 4;
-    overflow: hidden;
-    @include rtl(clear, left, right);
-
-    &[hidden] {
-      // Upon entering the DOM, messages should be hidden
-      md-message,
-      [md-message] {
-        opacity: 0;
-        margin-top: -100px;
-      }
-    }
-  }
-
   md-message, [md-message],
   .md-char-counter {
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
-    overflow: hidden;
-
-    transition: $swift-ease-in;
-
-    // Default state for messages is to be visible
-    opacity: 1;
-    margin-top: 0;
-
-    // Add some top padding which is equal to half the difference between the expected height
-    // and the actual height
-    padding-top: $error-padding-top;
-
     &:not(.md-char-counter) {
       // Add some padding so that the messages don't touch the character counter
       @include rtl(padding-right, rem(0.5), 0);

--- a/ng2-material/components/input/input.scss
+++ b/ng2-material/components/input/input.scss
@@ -215,6 +215,11 @@ md-input-container {
   .md-char-counter {
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
+
+    // Add some top padding which is equal to half the difference between the expected height
+    // and the actual height
+    padding-top: $error-padding-top;
+
     &:not(.md-char-counter) {
       // Add some padding so that the messages don't touch the character counter
       @include rtl(padding-right, rem(0.5), 0);

--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -12,10 +12,9 @@ import {DOM} from "angular2/src/platform/dom/dom_adapter";
 import {TimerWrapper} from "angular2/src/facade/async";
 
 // TODO(jd): <select> hasFocus/hasValue classes
-// TODO(jelbourn): validation (will depend on Forms API).
+// TODO(jd): input container validation styles.
 // TODO(jelbourn): textarea resizing
 // TODO(jelbourn): max-length counter
-// TODO(jelbourn): placeholder property
 
 
 @Directive({
@@ -82,7 +81,7 @@ export class MdInputContainer implements AfterContentInit, OnChanges {
   // Whether the input inside of this container has focus.
   inputHasFocus: boolean = false;
 
-  // Whether the intput inside of this container has a placeholder
+  // Whether the input inside of this container has a placeholder
   inputHasPlaceholder: boolean = false;
 
   constructor(@Attribute('id') id: string, private _element: ElementRef) {

--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, Attribute, Host, SkipSelf, AfterContentInit, ElementRef, forwardRef, OnChanges, ContentChild,
+  Directive, View, Component, Attribute, Host, SkipSelf, AfterContentInit, ElementRef, forwardRef, OnChanges, ContentChild,
   Query, QueryList, Optional
 } from 'angular2/core';
 
@@ -61,13 +61,16 @@ export class MdInput {
 }
 
 
-@Directive({
+@Component({
   selector: 'md-input-container',
   host: {
     '[class.md-input-has-value]': 'inputHasValue',
     '[class.md-input-has-placeholder]': 'inputHasPlaceholder',
     '[class.md-input-focused]': 'inputHasFocus',
   }
+})
+@View({
+  template: `<ng-content></ng-content><div class="md-errors-spacer"></div>`
 })
 export class MdInputContainer implements AfterContentInit, OnChanges {
 

--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -1,22 +1,90 @@
-import {Directive, Attribute, Host, SkipSelf, AfterContentChecked, ElementRef} from 'angular2/core';
+import {
+  Directive, Attribute, Host, SkipSelf, AfterContentInit, ElementRef, forwardRef, OnChanges, ContentChild,
+  Query, QueryList, OnInit, Optional
+} from 'angular2/core';
+
+import {NgControlName, FORM_PROVIDERS} from 'angular2/common';
 
 import {ObservableWrapper, EventEmitter} from 'angular2/src/facade/async';
 import {Input,Output} from 'angular2/core';
+import {isPresent} from 'angular2/src/facade/lang';
+import {DOM} from "angular2/src/platform/dom/dom_adapter";
+import {TimerWrapper} from "angular2/src/facade/async";
+
+export * from './input_validators';
 
 // TODO(jelbourn): validation (will depend on Forms API).
 // TODO(jelbourn): textarea resizing
 // TODO(jelbourn): max-length counter
 // TODO(jelbourn): placeholder property
 
+
+@Directive({
+  selector: 'input[md-input],input.md-input,textarea[md-input],textarea.md-input',
+  host: {
+    'class': 'md-input',
+    '[value]': 'value',
+    '(input)': 'value=$event.target.value',
+    '(focus)': 'setHasFocus(true)',
+    '(blur)': 'setHasFocus(false)'
+  },
+  providers: [FORM_PROVIDERS]
+})
+export class MdInput implements OnInit {
+  @Input('value')
+  _value: string;
+
+  set value(value: string) {
+    this._value = isPresent(value) ? value : '';
+    ObservableWrapper.callEmit(this.mdChange, this.value);
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  @Input()
+  placeholder: string;
+  @Output()
+  mdChange: EventEmitter<any> = new EventEmitter();
+  @Output()
+  mdFocusChange: EventEmitter<any> = new EventEmitter();
+
+  constructor(@Attribute('value') value: string,
+              @Attribute('id') id: string,
+              @Optional() private _ctrl: NgControlName) {
+    if (isPresent(value)) {
+      this.value = value;
+    }
+  }
+
+  ngOnInit() {
+    if(this._ctrl){
+      this._ctrl.formDirective.control.statusChanges.subscribe((c) => {
+        console.log(c);
+      });
+    }
+    console.log(this._ctrl);
+  }
+
+  setHasFocus(hasFocus: boolean) {
+    ObservableWrapper.callEmit(this.mdFocusChange, hasFocus);
+  }
+}
+
+
 @Directive({
   selector: 'md-input-container',
   host: {
     '[class.md-input-has-value]': 'inputHasValue',
+    '[class.md-input-has-placeholder]': 'inputHasPlaceholder',
     '[class.md-input-focused]': 'inputHasFocus',
   }
 })
-export class MdInputContainer implements AfterContentChecked {
+export class MdInputContainer implements AfterContentInit, OnChanges {
+
   // The MdInput or MdTextarea inside of this container.
+  @ContentChild(MdInput)
   _input: MdInput = null;
 
   // Whether the input inside of this container has a non-empty value.
@@ -25,67 +93,39 @@ export class MdInputContainer implements AfterContentChecked {
   // Whether the input inside of this container has focus.
   inputHasFocus: boolean = false;
 
-  constructor(@Attribute('id') id: string) {
+  // Whether the intput inside of this container has a placeholder
+  inputHasPlaceholder: boolean = false;
+
+  constructor(@Attribute('id') id: string, private _element: ElementRef) {
   }
 
-  ngAfterContentChecked() {
-    // Enforce that this directive actually contains a text input.
+  ngOnChanges(_) {
+    this.inputHasValue = this._input.value != '';
+
+    // TODO(jdd): Is there something like @ContentChild that accepts a selector? I would prefer not to
+    // use a directive for label elements because I cannot use a parent->child selector to make them
+    // specific to md-input
+    this.inputHasPlaceholder = !!DOM.querySelector(this._element.nativeElement, 'label') && !!this._input.placeholder;
+  }
+
+  ngAfterContentInit() {
+    // If there is no text input, just bail and do nothing.
     if (this._input === null) {
-      throw 'No <input> or <textarea> found inside of <md-input-container>';
-    }
-  }
-
-  /** Registers the child MdInput or MdTextarea. */
-  registerInput(input) {
-    if (this._input !== null) {
-      throw 'Only one text input is allowed per <md-input-container>.';
+      return;
     }
 
-    this._input = input;
-    this.inputHasValue = input.value != '';
+    TimerWrapper.setTimeout(() => this.ngOnChanges({}), 0);
 
     // Listen to input changes and focus events so that we can apply the appropriate CSS
     // classes based on the input state.
-    ObservableWrapper.subscribe(input.mdChange, value => {
+    ObservableWrapper.subscribe(this._input.mdChange, (value) => {
       this.inputHasValue = value != '';
     });
 
-    ObservableWrapper.subscribe<boolean>(input.mdFocusChange,
-                                         hasFocus => this.inputHasFocus = hasFocus);
+    ObservableWrapper.subscribe<boolean>(this._input.mdFocusChange, (hasFocus: boolean) => {
+      this.inputHasFocus = hasFocus
+    });
+
   }
 }
 
-
-@Directive({
-  selector: 'input[md-input],input.md-input,textarea[md-input],textarea.md-input',
-  providers: [MdInputContainer],
-  host: {
-    'class': 'md-input',
-    '(input)': 'updateValue($event)',
-    '(focus)': 'setHasFocus(true)',
-    '(blur)': 'setHasFocus(false)'
-  }
-})
-export class MdInput {
-  @Input() value: string;
-
-  // Events emitted by this directive. We use these special 'md-' events to communicate
-  // to the parent MdInputContainer.
-  @Output() mdChange: EventEmitter<any> = new EventEmitter();
-  @Output() mdFocusChange: EventEmitter<any> = new EventEmitter();
-
-  constructor(@Attribute('value') value: string, @SkipSelf() @Host() container: MdInputContainer,
-              @Attribute('id') id: string) {
-    this.value = value == null ? '' : value;
-    container.registerInput(this);
-  }
-
-  updateValue(event) {
-    this.value = event.target.value;
-    ObservableWrapper.callEmit(this.mdChange, this.value);
-  }
-
-  setHasFocus(hasFocus: boolean) {
-    ObservableWrapper.callEmit(this.mdFocusChange, hasFocus);
-  }
-}

--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -1,6 +1,6 @@
 import {
   Directive, Attribute, Host, SkipSelf, AfterContentInit, ElementRef, forwardRef, OnChanges, ContentChild,
-  Query, QueryList, OnInit, Optional
+  Query, QueryList, Optional
 } from 'angular2/core';
 
 import {NgControlName, FORM_PROVIDERS} from 'angular2/common';
@@ -10,9 +10,6 @@ import {Input,Output} from 'angular2/core';
 import {isPresent} from 'angular2/src/facade/lang';
 import {DOM} from "angular2/src/platform/dom/dom_adapter";
 import {TimerWrapper} from "angular2/src/facade/async";
-
-export * from './input_validators';
-
 
 // TODO(jd): <select> hasFocus/hasValue classes
 // TODO(jelbourn): validation (will depend on Forms API).
@@ -32,7 +29,7 @@ export * from './input_validators';
   },
   providers: [FORM_PROVIDERS]
 })
-export class MdInput implements OnInit {
+export class MdInput {
   @Input('value')
   _value: string;
 
@@ -53,20 +50,10 @@ export class MdInput implements OnInit {
   mdFocusChange: EventEmitter<any> = new EventEmitter();
 
   constructor(@Attribute('value') value: string,
-              @Attribute('id') id: string,
-              @Optional() private _ctrl: NgControlName) {
+              @Attribute('id') id: string) {
     if (isPresent(value)) {
       this.value = value;
     }
-  }
-
-  ngOnInit() {
-    if(this._ctrl){
-      this._ctrl.formDirective.control.statusChanges.subscribe((c) => {
-        console.log(c);
-      });
-    }
-    console.log(this._ctrl);
   }
 
   setHasFocus(hasFocus: boolean) {
@@ -116,6 +103,10 @@ export class MdInputContainer implements AfterContentInit, OnChanges {
       return;
     }
 
+    // TODO(jd): :sob: what is the correct way to update these variables after the component initializes?
+    //  any time I do it directly here, debug mode complains about values changing after being checked. I
+    //  need to wait until the content has been initialized so that `_input` is there
+    // For now, just wrap it in a setTimeout to let the change detection finish up, and then set the values...
     TimerWrapper.setTimeout(() => this.ngOnChanges({}), 0);
 
     // Listen to input changes and focus events so that we can apply the appropriate CSS

--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -13,6 +13,8 @@ import {TimerWrapper} from "angular2/src/facade/async";
 
 export * from './input_validators';
 
+
+// TODO(jd): <select> hasFocus/hasValue classes
 // TODO(jelbourn): validation (will depend on Forms API).
 // TODO(jelbourn): textarea resizing
 // TODO(jelbourn): max-length counter
@@ -102,7 +104,7 @@ export class MdInputContainer implements AfterContentInit, OnChanges {
   ngOnChanges(_) {
     this.inputHasValue = this._input.value != '';
 
-    // TODO(jdd): Is there something like @ContentChild that accepts a selector? I would prefer not to
+    // TODO(jd): Is there something like @ContentChild that accepts a selector? I would prefer not to
     // use a directive for label elements because I cannot use a parent->child selector to make them
     // specific to md-input
     this.inputHasPlaceholder = !!DOM.querySelector(this._element.nativeElement, 'label') && !!this._input.placeholder;

--- a/ng2-material/components/input/input_validators.ts
+++ b/ng2-material/components/input/input_validators.ts
@@ -1,0 +1,66 @@
+import {CONST_EXPR} from "angular2/src/facade/lang";
+import {NG_VALIDATORS} from "angular2/common";
+import {Attribute, Input, Provider, Directive,forwardRef} from "angular2/core";
+import {Validator} from "angular2/common";
+import {Control} from "angular2/common";
+import {isPresent} from "angular2/src/facade/lang";
+
+const PATTERN_VALIDATOR = CONST_EXPR(new Provider(NG_VALIDATORS, {
+  useExisting: forwardRef(() => MdPatternValidator),
+  multi: true
+}));
+
+@Directive({
+  selector: '[mdPattern]',
+  providers: [PATTERN_VALIDATOR]
+})
+export class MdPatternValidator implements Validator {
+
+  @Input('mdPattern') mdPattern: string;
+
+  constructor(@Attribute('mdPattern') pattern: any) {
+    if (isPresent(pattern)) {
+      this.mdPattern = pattern;
+    }
+  }
+
+  validate(control: Control): {[key: string]: any} {
+    if (control.value === '' || new RegExp(this.mdPattern).test(control.value)) {
+      return null;
+    }
+    return {
+      mdPattern: true
+    };
+  }
+}
+
+const MAXLENGTH_VALIDATOR = CONST_EXPR(new Provider(NG_VALIDATORS, {
+  useExisting: forwardRef(() => MdMaxLengthValidator),
+  multi: true
+}));
+
+@Directive({
+  selector: '[mdMaxLength]',
+  providers: [MAXLENGTH_VALIDATOR]
+})
+export class MdMaxLengthValidator implements Validator {
+
+  @Input('mdMaxLength') mdMaxLength: string;
+
+  constructor(@Attribute('mdMaxLength') attr: any) {
+    if (isPresent(attr)) {
+      this.mdMaxLength = attr;
+    }
+  }
+
+  validate(control: Control): {[key: string]: any} {
+    if (!control.value || control.value.length <= parseInt(this.mdMaxLength, 10)) {
+      return null;
+    }
+    return {
+      mdMaxLength: true
+    };
+  }
+}
+
+export const INPUT_VALIDATORS = [MdMaxLengthValidator, MdPatternValidator];

--- a/ng2-material/core/util/util.ts
+++ b/ng2-material/core/util/util.ts
@@ -50,3 +50,8 @@ export function rAF(callback) {
 export function parseTabIndexAttribute(attr: any): number {
   return isPresent(attr) ? NumberWrapper.parseInt(attr, 10) : 0;
 }
+
+
+export function isNumber(value: any): boolean {
+  return toString.call(value) === '[object Number]';
+}

--- a/ng2-material/core/util/util.ts
+++ b/ng2-material/core/util/util.ts
@@ -53,5 +53,5 @@ export function parseTabIndexAttribute(attr: any): number {
 
 
 export function isNumber(value: any): boolean {
-  return toString.call(value) === '[object Number]';
+  return Object.prototype.toString.call(value) === '[object Number]';
 }

--- a/test/components/dialog/dialog_spec.ts
+++ b/test/components/dialog/dialog_spec.ts
@@ -17,7 +17,6 @@ import {ComponentFixture} from "angular2/testing";
 import {findChildByTag} from "../../util";
 import {findChildById} from "../../util";
 import {MdDialogRef, MdDialogConfig, MdDialog, MdDialogBasic} from "../../../ng2-material/components/dialog/dialog";
-import {TimerWrapper} from "angular2/src/facade/async";
 import {DOM} from "angular2/src/platform/dom/dom_adapter";
 
 

--- a/test/components/form/messages_spec.ts
+++ b/test/components/form/messages_spec.ts
@@ -1,0 +1,132 @@
+import {
+  AsyncTestCompleter,
+  TestComponentBuilder,
+  beforeEach,
+  beforeEachProviders,
+  describe,
+  expect,
+  inject,
+  it,
+} from 'angular2/testing_internal';
+import {DebugElement} from 'angular2/src/core/debug/debug_element';
+import {Component, View, provide} from 'angular2/core';
+import {UrlResolver} from 'angular2/compiler';
+import {TestUrlResolver} from '../../test_url_resolver';
+import {MdMessage, MdMessages} from '../../../ng2-material/components/form/messages';
+import {MATERIAL_PROVIDERS} from '../../../ng2-material/all';
+import {ComponentFixture} from "angular2/testing";
+import {CORE_DIRECTIVES, FORM_DIRECTIVES, NgFormControl, NgFormModel, NgControlName} from "angular2/common";
+import {findChildrenByAttribute,findChildrenByTag,findChildByTag} from "../../util";
+import {TimerWrapper} from "angular2/src/facade/async";
+import {Ink} from "../../../ng2-material/core/util/ink";
+import {findChildByAttribute} from "../../util";
+
+
+export function main() {
+
+  interface IFormMessagesFixture {
+    fixture:ComponentFixture;
+    container:MdMessages;
+    messages:MdMessage[];
+  }
+  @Component({selector: 'test-app'})
+  @View({
+    directives: [CORE_DIRECTIVES, FORM_DIRECTIVES, MdMessage, MdMessages],
+    template: `
+    <form>
+      <input ngControl="name" required #name="ngForm"/>
+      <section [md-messages]="name">
+        <div md-message="required">required</div>
+      </section>
+    </form>`
+  })
+  class TestComponent {
+    name: string = 'MorTon';
+  }
+
+  describe('Form Messages', () => {
+    let builder: TestComponentBuilder;
+
+    function setup(template: string = null): Promise<IFormMessagesFixture> {
+      let prep = template === null ?
+        builder.createAsync(TestComponent) :
+        builder.overrideTemplate(TestComponent, template).createAsync(TestComponent);
+      return prep.then((fixture: ComponentFixture) => {
+        fixture.detectChanges();
+        let container = <MdMessages>findChildByAttribute(fixture.debugElement, 'md-messages').componentInstance;
+        let messages = <MdMessage[]>findChildrenByAttribute(fixture.debugElement, 'md-message').map(b => b.componentInstance);
+        return {
+          fixture: fixture,
+          container: container,
+          messages: messages
+        };
+      });
+    }
+
+    function getByInstance<T>(debug: DebugElement, type: any): T {
+      let found = debug.query((debugEl: DebugElement) => {
+        return debugEl.componentInstance instanceof type;
+      });
+      return <T>(found ? found.componentInstance : null);
+    }
+
+    beforeEachProviders(() => [MATERIAL_PROVIDERS, provide(UrlResolver, {useValue: new TestUrlResolver()}),]);
+    beforeEach(inject([TestComponentBuilder], (tcb) => builder = tcb));
+
+    describe('md-messages', () => {
+      it('should error if used outside of an NgFormControl', inject([AsyncTestCompleter], (async) => {
+        setup(`<div md-messages></div>`).catch((err: any) => {
+          expect(err).toBeDefined();
+          async.done();
+        });
+      }));
+      it('should initialize when given model and control group are present', inject([AsyncTestCompleter], (async) => {
+        setup().then((api: IFormMessagesFixture) => {
+          expect(api.container.isTouched).toBe(false);
+          async.done();
+          api.fixture.destroy();
+        });
+      }));
+      it('should bind local view references #ref="ngForm"', inject([AsyncTestCompleter], (async) => {
+        setup().then((api: IFormMessagesFixture) => {
+          expect(api.container.isTouched).toBe(false);
+          expect(api.messages.length).toBe(1);
+          expect(api.container.form).not.toBeNull();
+          expect(api.fixture.componentInstance.name).toBe('MorTon');
+          async.done();
+        });
+      }));
+      // TODO(jd): how to test form value changes? Need to change the control and have it
+      // trigger its own change events so that md-messages picks them up.
+      //it('should add md-valid and md-invalid classes to host', inject([AsyncTestCompleter], (async) => {
+      //  setup().then((api: IFormMessagesFixture) => {
+      //    TimerWrapper.setTimeout(()=> {
+      //      let app: TestComponent = api.fixture.componentInstance;
+      //      expect(app.name).toBe('MorTon');
+      //      expect(api.container.valid).toBe(true);
+      //      app.name = null;
+      //      let form = getByInstance<NgControlName>(api.fixture.debugElement, NgControlName);
+      //      form.control.updateValue('');
+      //      api.fixture.detectChanges();
+      //      expect(api.container.valid).toBe(false);
+      //
+      //      async.done();
+      //    }, 0);
+      //
+      //  });
+      //}));
+    });
+
+
+// TODO(jd): Behaviors to test
+// - md-messages with no md-message children act as message for all errors in a field
+// - md-message="propName" binds to FormBuilder group by given name
+// - [md-messages]="viewLocal" binds to given NgControlName referenced from the view
+// - [md-messages] adds md-valid and md-invalid class based on field validation state
+// - throws informative errors when it fails to bind to a given form field because it cannot be found.
+
+  });
+
+
+}
+

--- a/test/components/form/messages_spec.ts
+++ b/test/components/form/messages_spec.ts
@@ -85,7 +85,7 @@ export function main() {
           expect(api.container.isTouched).toBe(false);
           async.done();
           api.fixture.destroy();
-        });
+        }).catch((e) => console.log(e));
       }));
       it('should bind local view references #ref="ngForm"', inject([AsyncTestCompleter], (async) => {
         setup().then((api: IFormMessagesFixture) => {
@@ -94,7 +94,7 @@ export function main() {
           expect(api.container.form).not.toBeNull();
           expect(api.fixture.componentInstance.name).toBe('MorTon');
           async.done();
-        });
+        }).catch((e) => console.log(e));
       }));
       // TODO(jd): how to test form value changes? Need to change the control and have it
       // trigger its own change events so that md-messages picks them up.

--- a/test/components/form/validators_spec.ts
+++ b/test/components/form/validators_spec.ts
@@ -1,0 +1,42 @@
+import {describe,it,expect} from 'angular2/testing_internal';
+import {ControlGroup, Control, Validators, AbstractControl} from 'angular2/common';
+import {MdPatternValidator} from "../../../ng2-material/components/form/validators";
+import {MdNumberRequiredValidator} from "../../../ng2-material/components/form/validators";
+
+export function main() {
+
+  describe("Validators", () => {
+    describe("MdPatternValidator", () => {
+      it("should not error when pattern is found", () => {
+        let v = MdPatternValidator.inline('[a-z]+');
+        expect(v(new Control("abcd"))).toEqual(null);
+      });
+
+      it("should error when pattern is not found", () => {
+        let v = MdPatternValidator.inline('[a-z]+');
+        expect(v(new Control("1234"))).toEqual({mdPattern: true});
+      });
+      it("should error when pattern is not found", () => {
+        let v = MdPatternValidator.inline('[a-z]+');
+        expect(v(new Control("1234"))).toEqual({mdPattern: true});
+      });
+    });
+    describe("MdNumberRequiredValidator", () => {
+      let v = MdNumberRequiredValidator.inline();
+      it("should not error when number is found", () => {
+        expect(v(new Control(2))).toEqual(null);
+      });
+      it("should error when number is a string", () => {
+        expect(v(new Control("1234"))).toEqual({mdNumberRequired: true});
+      });
+      it("should error when given NaN", () => {
+        expect(v(new Control(NaN))).toEqual({mdNumberRequired: true});
+      });
+      it("should error when given nonsense values", () => {
+        expect(v(new Control(null))).toEqual({mdNumberRequired: true});
+        expect(v(new Control(undefined))).toEqual({mdNumberRequired: true});
+        expect(v(new Control('sunset'))).toEqual({mdNumberRequired: true});
+      });
+    });
+  });
+}

--- a/test/components/progress_circular/progress_circular_spec.ts
+++ b/test/components/progress_circular/progress_circular_spec.ts
@@ -17,7 +17,6 @@ import {MATERIAL_PROVIDERS} from '../../../ng2-material/all';
 import {ComponentFixture} from "angular2/testing";
 import {CORE_DIRECTIVES} from "angular2/common";
 import {findChildrenByAttribute,findChildrenByTag,findChildByTag} from "../../util";
-import {TimerWrapper} from "angular2/src/facade/async";
 import {Ink} from "../../../ng2-material/core/util/ink";
 import {ProgressMode} from "../../../ng2-material/components/progress_linear/progress_linear";
 import {MdProgressCircular} from "../../../ng2-material/components/progress_circular/progress_circular";

--- a/test/components/progress_linear/progress_linear_spec.ts
+++ b/test/components/progress_linear/progress_linear_spec.ts
@@ -17,7 +17,6 @@ import {MATERIAL_PROVIDERS} from '../../../ng2-material/all';
 import {ComponentFixture} from "angular2/testing";
 import {CORE_DIRECTIVES} from "angular2/common";
 import {findChildrenByAttribute,findChildrenByTag,findChildByTag} from "../../util";
-import {TimerWrapper} from "angular2/src/facade/async";
 import {Ink} from "../../../ng2-material/core/util/ink";
 import {MdProgressLinear, ProgressMode} from "../../../ng2-material/components/progress_linear/progress_linear";
 

--- a/test/components/tabs/tabs_spec.ts
+++ b/test/components/tabs/tabs_spec.ts
@@ -17,7 +17,6 @@ import {MATERIAL_PROVIDERS} from '../../../ng2-material/all';
 import {ComponentFixture} from "angular2/testing";
 import {CORE_DIRECTIVES} from "angular2/common";
 import {findChildrenByAttribute,findChildrenByTag,findChildByTag} from "../../util";
-import {TimerWrapper} from "angular2/src/facade/async";
 import {Ink} from "../../../ng2-material/core/util/ink";
 
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -30,6 +30,8 @@
         "ng2-material/components/dialog/dialog_container.ts",
         "ng2-material/components/dialog/dialog_ref.ts",
         "ng2-material/components/divider/divider.ts",
+        "ng2-material/components/form/messages.ts",
+        "ng2-material/components/form/validators.ts",
         "ng2-material/components/grid_list/grid_list.ts",
         "ng2-material/components/icon/icon.ts",
         "ng2-material/components/input/input.ts",


### PR DESCRIPTION
Support basic forms and validation with the input and input-container components.

 - [x] Support declarative validators in markup
 - [x] Support FormBuilder groups in code
 - [x] Add `md-messages` and `md-message` directives for specifying messages associated with form inputs
 - [x] Examples of using `md-input-container` and `md-input` with both styles of validation
 - [x] Basic tests for messages components
 - [x] Basic tests for validators

## Declare validations in markup
```html
<md-input-container>
  <label for="postalCode">Postal Code</label>
  <input md-input ngControl="postalCode" [(value)]="user.postalCode"
         required mdPattern="^[0-9]{5}$" #postalCode="ngForm">
  <div [md-messages]="postalCode" role="alert">
    <div md-message="required">You must supply a postal code.</div>
    <div md-message="mdPattern">That doesn't look like a valid postal code.</div>
  </div>
</md-input-container>
```

## Declare validations in FormBuilder

```typescript
@Component({...})
@View({...})
export class InputFormBuilder {
  projectForm: ControlGroup;
  postalCode: string = '';
  constructor(fb: FormBuilder) {
    this.projectForm = fb.group({
      'postalCode': ['', Validators.compose([
        MdPatternValidator.inline('^[0-9]{5}$'),
        Validators.required
      ])]
    });
  }
}

```

```html
<md-input-container>
  <label for="postalCode">Postal Code</label>
  <input md-input ngControl="postalCode" [(value)]="user.postalCode" id="postalCode">
  <div [md-messages]="postalCode" role="alert">
    <div md-message="required">You must supply a postal code.</div>
    <div md-message="mdPattern">That doesn't look like a valid postal code.</div>
  </div>
</md-input-container>

```
