### PR TITLE
enable click event handling of items in menu

### DIFF
--- a/examples/app.html
+++ b/examples/app.html
@@ -8,7 +8,8 @@
     <md-list>
       <md-list-item md-ink (inked)="navigate(['Component', {id: value.id}])"
                     [class.md-active]="navigation?.currentTitle==value.name"
-                    *ngFor="#value of components">
+                    *ngFor="#value of components"
+                    (click)="navigate(['Component', {id: value.id}])">
         {{value.name}}
       </md-list-item>
     </md-list>
@@ -81,4 +82,3 @@
 
   </section>
 </md-sidenav-container>
-


### PR DESCRIPTION
Adding click event processing to the components listed in the menu makes this example a bit more complete.

