### PR TITLE
Added support for building single js file using webpack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,6 +236,9 @@ module.exports = function (grunt) {
           }
         }
       }
+    },
+    webpack: {
+      singleJs: require('./webpack.config.js')
     }
 
   });
@@ -250,11 +253,13 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-ts');
   grunt.loadNpmTasks('dts-generator');
   grunt.loadNpmTasks('remap-istanbul');
+  grunt.loadNpmTasks('grunt-webpack');
+
   grunt.registerTask('default', ['dtsGenerator', 'ts:source', 'sass', 'postcss', 'site-meta']);
   grunt.registerTask('develop', ['default', 'watch']);
   grunt.registerTask('cover', ['karma:cover', 'remapIstanbul', 'site-meta']);
   grunt.registerTask('site', ['build', 'cover', 'copy:site']);
-  grunt.registerTask('build', ['default', 'ts:release', 'dist-bundle', 'copy:release']);
+  grunt.registerTask('build', ['default', 'ts:release', 'dist-bundle', 'copy:release', 'webpack']);
 
 
   grunt.registerTask('dist-bundle', 'Build a single-file javascript output.', function () {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   "devDependencies": {
     "autoprefixer": "6.2.0",
     "coveralls": "2.11.6",
+    "css-loader": "^0.23.1",
     "dts-generator": "1.6.3",
     "es6-module-loader": "^0.17.4",
+    "file-loader": "^0.8.5",
     "glob": "6.0.1",
     "grunt": "0.4.5",
     "grunt-bump": "0.7.0",
@@ -43,6 +45,7 @@
     "grunt-npm": "0.0.2",
     "grunt-postcss": "0.7.1",
     "grunt-ts": "5.2.0",
+    "grunt-webpack": "^1.0.11",
     "highlightjs": "8.7.0",
     "istanbul": "1.0.0-alpha.2",
     "karma": "0.13.19",
@@ -55,8 +58,12 @@
     "lcov-parse": "0.0.10",
     "marked": "0.3.5",
     "remap-istanbul": "0.4.0",
+    "style-loader": "^0.13.0",
     "systemjs-builder": "justindujardin/builder.git#typescript-source-maps",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.13",
+    "webpack-dev-server": "^1.14.1"
   },
   "contributors": [
     "Justin DuJardin <justindujardin@users.noreply.github.com>",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,13 @@
 module.exports = {
-  entry: [
-    './webpack/style.js',
-    './webpack/all.js'
-  ],
+  entry: {
+    'all-webpack': './webpack/all.js',
+    'all-styles': './webpack/style.js'
+  },
   output: {
     // We use CommonJS because of Meteor 1.3 specification that uses it
     libraryTarget: 'commonjs',
     path: './out/',
-    filename: "all.webpack.js"
+    filename: "[name].js"
   },
   resolve: {
     extensions: ['', '.webpack.js', '.web.js', '.css', '.js']

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,38 @@
+module.exports = {
+  entry: [
+    './webpack/style.js',
+    './webpack/all.js'
+  ],
+  output: {
+    // We use CommonJS because of Meteor 1.3 specification that uses it
+    libraryTarget: 'commonjs',
+    path: './out/',
+    filename: "all.webpack.js"
+  },
+  resolve: {
+    extensions: ['', '.webpack.js', '.web.js', '.css', '.js']
+  },
+  externals: [
+    /angular2\/.*/
+  ],
+  module: {
+    loaders: [
+      {
+        test: /\.woff$/,
+        loader: 'url?limit=100000'
+      },
+      {
+        test: /\.woff2$/,
+        loader: 'url?limit=100000'
+      },
+      {
+        test: /\.ttf/,
+        loader: 'url?limit=100000'
+      },
+      {
+        test: /\.eot/,
+        loader: 'url?limit=100000'
+      }
+    ]
+  }
+};

--- a/webpack/all.js
+++ b/webpack/all.js
@@ -1,0 +1,3 @@
+module.exports = require('../out/all.js');
+require('style!css!../out/all.css');
+require('style!css!../out/font/font.css');

--- a/webpack/style.js
+++ b/webpack/style.js
@@ -1,0 +1,2 @@
+require('style!css!../out/all.css');
+require('style!css!../out/font/font.css');


### PR DESCRIPTION
- Added webpack build process which adds to the `out` directory a single js file.
- The file is consumable by CommonJS.
- Two new out files: 
`all-webpack.js`- contains all JS files, fonts, fonts css and CSS files.
`all-styles.js`- contains all fonts, fonts css and CSS files.
- Updated the Grunt build process to run this when building.

Those files are requires for platforms that supports NPM modules but does not support the ability to import assets from node_modules, such as Meteor 1.3-beta7 (**at the moment there is no support, might change**)
