### PR TITLE
Missing import of mixins

### DIFF
--- a/ng2-material/components/sidenav/sidenav.scss
+++ b/ng2-material/components/sidenav/sidenav.scss
@@ -1,6 +1,7 @@
 @import "../../core/style/variables";
 @import "../../core/style/shadows";
 @import "../../core/style/default-theme";
+@import "../../core/style/mixins";
 
 $sidenav-mobile-width: 320px !default;
 $sidenav-desktop-width: 400px !default;


### PR DESCRIPTION
Component scss fails due to missing import of `md-stacking-context` from `mixins` that is required in line 21 (now 22).