### PR TITLE
Add HTML content support to basic dialog

### DIFF
--- a/ng2-material/components/dialog/dialog_basic.ts
+++ b/ng2-material/components/dialog/dialog_basic.ts
@@ -10,6 +10,7 @@ import {Input} from "angular2/core";
   template: `
   <h2 class="md-title">{{ title }}</h2>
   <p>{{ textContent }}</p>
+  <md-dialog-content [innerHTML]="HTMLContent"></md-dialog-content>
   <md-dialog-actions>
     <button md-button *ngIf="cancel != ''" type="button" (click)="dialog.close(false)">
       <span>{{ cancel }}</span>
@@ -23,6 +24,7 @@ import {Input} from "angular2/core";
 export class MdDialogBasic {
   @Input() title: string = '';
   @Input() textContent: string = '';
+  @Input() HTMLContent: string = '';
   @Input() cancel: string = '';
   @Input() ok: string = '';
   @Input() type: string = 'alert';

--- a/ng2-material/components/dialog/dialog_config.ts
+++ b/ng2-material/components/dialog/dialog_config.ts
@@ -31,6 +31,11 @@ export class MdDialogConfig {
     return this;
   }
 
+  HTMLContent(html: string): MdDialogConfig {
+    this.context.HTMLContent = html;
+    return this;
+  }
+
   ariaLabel(text: string): MdDialogConfig {
     this.context.ariaLabel = text;
     return this;


### PR DESCRIPTION
Enable the user to inject HTML content into the modal-dialog-content directive via the config method ```HTMLContent()```

I think it's a great alternative to custom template via custom dialog if you merely need to insert some HTML in your dialog content. 