### PR TITLE
Relax dependency constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "angular2": "^2.0.0-beta.9",
-    "es6-promise": "3.0.2",
-    "es6-shim": "0.33.13",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "^5.0.0-beta.2",
     "zone.js": "^0.5.15"


### PR DESCRIPTION
Angular Beta9 allow newer versions for es6-promise and es6-shim