### PR TITLE
Removed space between '@media screen' and '\0'

### DIFF
--- a/ng2-material/core/style/layout.scss
+++ b/ng2-material/core/style/layout.scss
@@ -167,7 +167,7 @@ $layout-breakpoint-lg: 1920px !default;
   // Do not use unitless flex-basis values in the flex shorthand because IE 10-11 will error.
   // Also use 0% instead of 0px since minifiers will often convert 0px to 0 (which is unitless and will have the same problem).
   // Safari, however, fails with flex-basis : 0% and requires flex-basis : 0px
-  @media screen \0
+  @media screen\0
   {
     [#{$flexName}] {
       flex: 1 1 0%;


### PR DESCRIPTION
Message: node_modules\ng2-material\source\core\style\layout.scss
Error: Invalid CSS after "  @media screen": expected "{", was "\\0" on line 170 of node_modules/ng2-material/source/core/style/layout.scss