### PR TITLE
fix: fix ProgressCircular tests about diameter

### DIFF
--- a/test/components/progress_circular/progress_circular_spec.ts
+++ b/test/components/progress_circular/progress_circular_spec.ts
@@ -89,7 +89,6 @@ export function main() {
       describe('diameter', () => {
         it('should set scaling using percentage values', injectAsync([], () => {
           return setup(`<md-progress-circular [diameter]="'25%'"></md-progress-circular>`).then((api: IProgressFixture) => {
-
             let compiled = api.fixture.nativeElement;
             let indicator = compiled.querySelector('md-progress-circular');
             let scaleWrapper = compiled.querySelector('.md-scale-wrapper');
@@ -134,8 +133,8 @@ export function main() {
      */
     function getScale(element) {
       var transform = element.style['transform'] || element.style['-webkit-transform'];
-      var matches = /scale\(\s*([0-9\.]+)\s*\)/.exec(transform);
-      var scale = parseFloat(matches[1]);
+      var matches = /scale\(\s*([0-9,\.]+)\s*\)/.exec(transform);
+      var scale = parseFloat(matches[1].replace(',', '.'));
 
       return Math.round(scale * 100) / 100;
     }


### PR DESCRIPTION
I don't know why but it seems that the scale is 0,25 instead of 0.25 on my laptop (a Mac... dunno if it occurs on other PCs too). So this fix repair the test in this case by allowing comma in the scale match and replace it by a dot before cast it to float.