### PR TITLE
fix: package.json to run tests and serve the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "scripts": {
-    "test": "npm install"
+    "start": "$(npm bin)/grunt serve",
+    "test": "$(npm bin)/grunt karma"
   },
   "dependencies": {
     "angular2": ">=2.0.0-beta.11",


### PR DESCRIPTION
`npm test` now run tests.

The feature may be in another but I feel lazy tonight ;) so
`npm start` serve the app


This one should fix #106 