### PR TITLE
fix: rxjs-dependency version need to be frozen for the moment.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "es6-promise": ">=3.0.2",
     "es6-shim": ">=0.35.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": ">=5.0.0-beta.2",
+    "rxjs": "5.0.0-beta.2",
     "zone.js": ">=0.6.4"
   },
   "typings": "dist/ng2-material.d.ts",


### PR DESCRIPTION
When Angular team will fix the dependency issue on their side, you can revert this fix to a more flexible version management

It should fix Travis and allow you @justindujardin to merge again ;)