### PR TITLE
feat: make visibility input available for sidenav

### DIFF
--- a/ng2-material/components/backdrop/backdrop.ts
+++ b/ng2-material/components/backdrop/backdrop.ts
@@ -86,7 +86,7 @@ export class MdBackdrop {
     this.toggle(value);
   }
 
-  private _visible: boolean = false;
+  protected _visible: boolean = false;
   private _transitioning: boolean = false;
   private _previousOverflow: string = null;
   private _body: HTMLElement = null;

--- a/ng2-material/components/sidenav/sidenav.ts
+++ b/ng2-material/components/sidenav/sidenav.ts
@@ -122,6 +122,18 @@ export class MdSidenav extends MdBackdrop implements OnInit, OnDestroy {
   private _style: string = SidenavStyle.OVER;
 
   /**
+   * allow backdrop visibility Input
+   */
+  get visible(): boolean {
+    return this._visible;
+  }
+
+  @Input()
+  set visible(value: boolean) {
+    this.toggle(value);
+  }
+
+  /**
    * The backdrop element the container provides.
    */
   backdropRef: MdBackdrop = null;

--- a/test/components/sidenav/sidenav_spec.ts
+++ b/test/components/sidenav/sidenav_spec.ts
@@ -120,6 +120,15 @@ export function main() {
         }));
 
       });
+
+      describe('visible', () => {
+        it('should accept "true" for content pushing', injectAsync([], () => {
+          return setup(`<md-sidenav [visible]="true"></md-sidenav>`).then((api: ITestFixture) => {
+            expect(api.component.visible).toBe(true);
+          });
+        }));
+
+      });
     });
     describe('md-sidenav-container', () => {
       let template = `


### PR DESCRIPTION
The `@Input` of `MdBackdrop` is actually unavailable on extended class like `MdSidenav`.
With this, you can set default visibility of a sidenav via `visible` input

it should fix #172 