### PR TITLE
Fix md-input caret jumping around when entering text

### DIFF
--- a/ng2-material/components/input/input.ts
+++ b/ng2-material/components/input/input.ts
@@ -25,7 +25,6 @@ import {DOM} from "angular2/src/platform/dom/dom_adapter";
   host: {
     'class': 'md-input',
     '[value]': 'value',
-    '(input)': 'value=$event.target.value',
     '(focus)': 'setHasFocus(true)',
     '(blur)': 'setHasFocus(false)'
   },


### PR DESCRIPTION
Fixes #105 #103 
Whenever you typed text into an md-input the cursor would jump to the end.

Tests all passed. Manual testing all seemed to work with data binding.
I'm not really sure what the purpose of that line was in the first place so I couldn't say for sure that it doesn't cause any other side effects.