### PR TITLE
Added support for InkBar when using Tab component. Plus tab bodies now slide in from the left/right

### DIFF
--- a/examples/components/tabs/dynamic_height.html
+++ b/examples/components/tabs/dynamic_height.html
@@ -1,13 +1,13 @@
 <md-tabs md-dynamic-height md-border-bottom>
-  <template md-tab label="one">
+  <md-tab label="one">
     <md-content class="md-padding">
       <h1 class="md-display-2">Tab One</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla venenatis ante augue. Phasellus volutpat neque
         ac dui mattis vulputate. Etiam consequat aliquam cursus. In sodales pretium ultrices. Maecenas lectus est,
         sollicitudin consectetur felis nec, feugiat ultricies mi.</p>
     </md-content>
-  </template>
-  <template md-tab label="two">
+  </md-tab>
+  <md-tab label="two">
     <md-content class="md-padding">
       <h1 class="md-display-2">Tab Two</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla venenatis ante augue. Phasellus volutpat neque
@@ -29,8 +29,8 @@
         nunc. Sed id ante eu orci commodo volutpat non ac est. Praesent ligula diam, congue eu enim scelerisque, finibus
         commodo lectus.</p>
     </md-content>
-  </template>
-  <template md-tab label="three">
+  </md-tab>
+  <md-tab label="three">
     <md-content class="md-padding">
       <h1 class="md-display-2">Tab Three</h1>
       <p>Integer turpis erat, porttitor vitae mi faucibus, laoreet interdum tellus. Curabitur posuere molestie dictum.
@@ -38,5 +38,5 @@
         nunc. Sed id ante eu orci commodo volutpat non ac est. Praesent ligula diam, congue eu enim scelerisque, finibus
         commodo lectus.</p>
     </md-content>
-  </template>
+  </md-tab>
 </md-tabs>

--- a/examples/components/tabs/dynamic_tabs.html
+++ b/examples/components/tabs/dynamic_tabs.html
@@ -1,6 +1,6 @@
 <md-content class="md-padding">
   <md-tabs [selected]="selectedIndex" md-border-bottom md-autoselect>
-    <template md-tab *ngFor="var tab of tabs"
+    <md-tab *ngFor="#tab of tabs"
               [disabled]="tab.disabled"
               [label]="tab.title">
       <div class="demo-tab tab{{index%4}}" style="padding: 25px; text-align: center;">
@@ -9,7 +9,7 @@
         <button md-raised-button class="md-primary" (click)="removeTab( tab )" [disabled]="tabs.length <= 1">Remove Tab
         </button>
       </div>
-    </template>
+    </md-tab>
   </md-tabs>
 </md-content>
 

--- a/examples/example.html
+++ b/examples/example.html
@@ -25,11 +25,11 @@
                [ngClass]="{ shown: showTabs }"
                mdNoScroll="true"
                class="demo-source-tabs md-primary md-no-scroll">
-        <template md-tab *ngFor="#file of orderedFiles" [label]="file?.type">
+        <md-tab *ngFor="#file of orderedFiles" [label]="file?.type">
           <md-content md-scroll-y class="demo-source-container">
             <highlight [text]="file.data" [type]="file.type" class="no-header"></highlight>
           </md-content>
-        </template>
+        </md-tab>
       </md-tabs>
 
       <!-- Live Demos -->

--- a/ng2-material/components/tabs/tabs.ts
+++ b/ng2-material/components/tabs/tabs.ts
@@ -7,6 +7,7 @@ import {
   TemplateRef,
   ViewEncapsulation,
   Query,
+  ViewChild,
   ElementRef
 } from "angular2/core";
 import {Ink} from "../../core/util/ink";
@@ -23,6 +24,18 @@ import {NgFor} from "angular2/common";
 //  - If you set the disabled attribute on a tab, it becomes unselectable
 //  - If you set md-theme=\"green\" on the md-tabs element, you'll get green tabs
 
+@Component({
+  selector: 'md-ink-bar',
+  template: ``
+})
+export class MdInkBar {
+  constructor(private _el: ElementRef) {
+  }
+
+  get elementRef(): ElementRef {
+    return this._el;
+  }
+}
 
 @Directive({
   selector: '[md-tab]'
@@ -83,11 +96,13 @@ export class MdTab {
         <ng-content></ng-content>
       </md-tab-content>
     </md-tabs-content-wrapper>`,
-  directives: [NgFor],
+  directives: [NgFor, MdInkBar],
   properties: ['selected'],
   encapsulation: ViewEncapsulation.None
 })
 export class MdTabs {
+  @ViewChild(MdInkBar)
+  inkBarComponent: MdInkBar;
 
   @Input()
   mdNoScroll: boolean = false;
@@ -98,6 +113,11 @@ export class MdTabs {
     this.panes.changes.subscribe((_) => {
       this.panes.toArray().forEach((p: MdTab, index: number) => {
         p.active = index === this._selected;
+        if (p.active) {
+          Ink.updateInkbar(this._element.nativeElement, 
+                    this.inkBarComponent.elementRef.nativeElement, 
+                    this._selected);
+        }
       });
     });
   }
@@ -138,9 +158,15 @@ export class MdTabs {
   }
 
   onTabClick(pane: MdTab, event?) {
+    let initialSelect = this._selected;
+    
     if (event && Ink.canApply(this._element.nativeElement)) {
       Ink.rippleEvent(event.target, event);
     }
     this.selectedTab = pane;
+    Ink.updateInkbar(this._element.nativeElement, 
+                        this.inkBarComponent.elementRef.nativeElement, 
+                        this._selected,
+                        initialSelect);  
   }
 }

--- a/ng2-material/core/util/ink.ts
+++ b/ng2-material/core/util/ink.ts
@@ -92,5 +92,34 @@ export class Ink {
     }
     return Ink.ripple(element, rippleX, rippleY);
   }
+  
+  /**
+   * Move the position of the inkbar to the active tab name
+   *
+   * @param element The parent element that holds the tabs
+   * @param inkbar The element for the inkbar
+   * @param activeIndex The index of the active tab
+   * @returns {Promise<any>} A promise that resolves when the ripple has faded.
+   */
+  static updateInkbar(element: HTMLElement, inkbar: HTMLElement, activeIndex: number, previousIndex?: number): Promise<any> {
+    let containers = DOM.querySelectorAll(element, 'md-tab-item');
 
+    if (activeIndex > containers.length) {
+      return Promise.resolve();
+    }
+
+    let getDirection = (): string => {
+      return (previousIndex > activeIndex) ? 'md-left' : 'md-right';
+    };
+
+    // Get new active tab
+    let container = containers[activeIndex];
+    let left = container.getBoundingClientRect().left - containers[0].getBoundingClientRect().left;
+    let width = container.getBoundingClientRect().width;
+
+    DOM.addClass(inkbar, getDirection())
+    return Animate.setStyles(inkbar, { left: `${left}px`, width: `${width}px` })
+      .then(() => Animate.wait(250))
+      .then(() => DOM.removeClass(inkbar, getDirection()));
+  }
 }


### PR DESCRIPTION
Active tab is highlighted by an ink bar. It moves as a new tab is selected.

Changes have been to add new InkBar component class, which is passed into MdTabs. When a new tab is selected, the movement of the InkBar is done via changes to the style of the InkBar implemented in Ink.ts

(Note the build is failing because Angular2 has been updated to Beta 16. Beta 16 has currently broken other parts of ng2-material, unrelated to the changes I have made. I have tested it against Beta 15)