### PR TITLE
chore(development tooling): Add TDD Grunt Task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,8 @@ And that's it! Now you run the Example app via `grunt serve` command, you can se
 ### Write some Tests
 
 Don't forget to write tests about your component. Even if it's pretty awesome, it could help to avoid regression in the future.
-Follow recommandations about [writing test in angular2][writing-test].  
+Follow recommandations about [writing test in angular2][writing-test].
+There is an npm script for Test Driven Development: `npm run tdd`, which can be helpful.
 When your tests pass and only after that, you can [propose a pull request](#how-to-contribute)
 
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,12 @@ module.exports = function (grunt) {
           '<%- sourceRoot %>/**/*.ts'
         ],
         tasks: ['ts:source', 'rewrite-source-maps', 'notify:source']
+      },
+      karma: {
+        files: [
+          '<%- sourceRoot %>/**/*.ts'
+        ],
+        tasks: ['karma']
       }
     },
 
@@ -194,6 +200,7 @@ module.exports = function (grunt) {
     }
   });
 
+  grunt.loadNpmTasks('grunt-continue');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-connect');
@@ -210,6 +217,8 @@ module.exports = function (grunt) {
   grunt.registerTask('cover', ['karma:cover', 'remapIstanbul', 'site-meta']);
   grunt.registerTask('site', ['build', 'cover', 'copy:site']);
   grunt.registerTask('build', ['default', 'copy:npm']);
+  grunt.registerTask('tddTasks', ['ts', 'continue:on', 'karma']);
+  grunt.registerTask('tdd', ['tddTasks', 'watch']);
 
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-conventional-changelog');

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "start": "$(npm bin)/grunt serve",
     "test": "$(npm bin)/grunt karma",
+    "tdd": "./node_modules/.bin/grunt tdd",
     "postinstall": "$(npm bin)/typings install"
   },
   "dependencies": {
@@ -42,6 +43,7 @@
     "grunt": "0.4.5",
     "grunt-bump": "0.7.0",
     "grunt-cli": "0.1.13",
+    "grunt-continue": "^0.1.0",
     "grunt-contrib-clean": "0.7.0",
     "grunt-contrib-connect": "0.11.2",
     "grunt-contrib-copy": "0.8.2",


### PR DESCRIPTION
Added a plugin to continue grunt process on karma on failure, used by
a new grunt task that just watches, compiles typescript, & runs karma,
The goal is helping contributers write unit tests, even a
test-driven workflow.

Also an `npm` script, `npm tdd` and a note about it in the docs.