### PR TITLE
feat(bootstrap): overlayContainerToken function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,15 @@ export const MATERIAL_NODE_PROVIDERS: any[] = [
  */
 export const MATERIAL_BROWSER_PROVIDERS: any[] = [
   ...MATERIAL_NODE_PROVIDERS,
-  provide(ViewportHelper, {useClass: BrowserViewportHelper}),
-  // TODO(jd): should this be here? Or in the example app bootstrap?
-  provide(OVERLAY_CONTAINER_TOKEN, {useValue: createOverlayContainer()}),
+  provide(ViewportHelper, {useClass: BrowserViewportHelper})
 ];
+
+/**
+ * Create OverlayContainer.
+ */
+export function overlayContainerToken(): any {
+  return provide(OVERLAY_CONTAINER_TOKEN, {useValue: createOverlayContainer()});
+}
 
 
 /**

--- a/src/platform/testing/bootstrap.ts
+++ b/src/platform/testing/bootstrap.ts
@@ -8,7 +8,7 @@ import {
   TEST_BROWSER_STATIC_PLATFORM_PROVIDERS,
   ADDITIONAL_TEST_BROWSER_PROVIDERS
 } from "@angular/platform-browser/testing";
-import {MATERIAL_BROWSER_PROVIDERS} from "../../index";
+import {MATERIAL_BROWSER_PROVIDERS, overlayContainerToken} from "../../index";
 import {TestUrlResolver} from "./test_url_resolver";
 import {UrlResolver} from "@angular/compiler";
 import {provide, ApplicationRef} from "@angular/core";
@@ -20,6 +20,7 @@ setBaseTestProviders(
     ...BROWSER_APP_DYNAMIC_PROVIDERS,
     ...ADDITIONAL_TEST_BROWSER_PROVIDERS,
     ...MATERIAL_BROWSER_PROVIDERS,
+    overlayContainerToken(),
     provide(ApplicationRef, {useClass: MockApplicationRef}),
     provide(UrlResolver, {useValue: new TestUrlResolver()})
   ]


### PR DESCRIPTION
Allows to defer bootstraping an application that depends on ng2-material

Thanks to this change there is no assumption of document.body being available at runtime

Closes #257

This is a breaking change because user instead of providing just the `MATERIAL_BROWSER_PROVIDERS` he also have to invoke `overlayContainerToken()`.