### PR TITLE
Set theme colors to be !default

### DIFF
--- a/src/core/style/default-theme.scss
+++ b/src/core/style/default-theme.scss
@@ -4,8 +4,8 @@
 // Person creating a theme writes variables like this:
 $md-is-dark-theme: false !default;
 
-$md-primary: md-palette($md-teal, 500, 100, 700, $md-contrast-palettes);
-$md-accent: md-palette($md-purple, 500, 300,800, $md-contrast-palettes);
-$md-warn: md-palette($md-red, 500, 300, 900, $md-contrast-palettes);
+$md-primary: md-palette($md-teal, 500, 100, 700, $md-contrast-palettes) !default;
+$md-accent: md-palette($md-purple, 500, 300,800, $md-contrast-palettes) !default;
+$md-warn: md-palette($md-red, 500, 300, 900, $md-contrast-palettes) !default;
 $md-background: md-palette($md-grey, 500, 0, 600, $md-contrast-palettes) !default;
 $md-foreground: if($md-is-dark-theme, $md-dark-theme-foreground, $md-light-theme-foreground) !default;


### PR DESCRIPTION
I found this issue while trying to overwrite the default theme styles. Because many of the components reference default-theme, my changes were being ignored since !default wasn't set.