### PR TITLE
fix(typings): remove in favor of npm @types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 node_js:
 - '5.6.0'
 before_install:
-- npm install -g karma-cli typings
+- npm install -g karma-cli
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "systemjs": "0.19.39",
     "tslint": "^3.15.1",
     "typescript": "^2.0.0",
-    "typings": "^1.3.3",
     "underscore": "1.8.3"
   },
   "contributors": [

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,0 @@
-{
-  "globalDependencies": {
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654"
-  }
-}


### PR DESCRIPTION
 - does not need typings installed, fixes issue where npm would fail during a postinstall step