### PR TITLE
chore: move grunt-sass to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@angular/router": "^3.0.0",
     "es6-promise": ">=3.3.1",
     "es6-shim": "^0.35.1",
-    "grunt-sass": "^1.2.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "^5.0.0-beta.12",
     "zone.js": "^0.6.23"
@@ -61,6 +60,7 @@
     "grunt-notify": "0.4.5",
     "grunt-npm": "0.0.2",
     "grunt-postcss": "0.8.0",
+    "grunt-sass": "^1.2.1",
     "grunt-ts": "6.0.0-beta.3",
     "highlightjs": "8.7.0",
     "istanbul": "1.0.0-alpha.2",


### PR DESCRIPTION
Because we copy the `dependencies` list when publishing a package, this would cause `grunt-sass` to be a dep of the release package.  Oops.