### PR TITLE
Fixed invalid sass markup

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -167,7 +167,7 @@ $layout-breakpoint-lg: 1920px !default;
   // Do not use unitless flex-basis values in the flex shorthand because IE 10-11 will error.
   // Also use 0% instead of 0px since minifiers will often convert 0px to 0 (which is unitless and will have the same problem).
   // Safari, however, fails with flex-basis : 0% and requires flex-basis : 0px
-  @media screen\0
+  @media #{"screen\\0"}
   {
     [#{$flexName}] {
       flex: 1 1 0%;


### PR DESCRIPTION
Issue: the `\0` character breaks node-sass.

Restores original fix for #122:
https://github.com/alexalexandresq/ng2-material/commit/134bac5287347dcd964a45455760133b34a8100c